### PR TITLE
Fix Creation of Instructor

### DIFF
--- a/src/ContosoUniversity/Models/Instructor.cs
+++ b/src/ContosoUniversity/Models/Instructor.cs
@@ -12,7 +12,7 @@ namespace ContosoUniversity.Models
         [Display(Name = "Hire Date")]
         public DateTime HireDate { get; set; }
 
-        public virtual ICollection<CourseInstructor> CourseInstructors { get; set; }
+        public virtual ICollection<CourseInstructor> CourseInstructors { get; set; } = new HashSet<CourseInstructor>();
         public virtual OfficeAssignment OfficeAssignment { get; set; }
     }
 


### PR DESCRIPTION
Fixing the creation of the instructor by initializing the Instructor collection. Before it would throw an exception at CreateEdit.cs Line 183. 

`var instructorCourses = new HashSet<int>
                    (instructorToUpdate.CourseInstructors.Select(c => c.CourseID));`
